### PR TITLE
AST-6508 - Jenkins - Not able to use environment variables (proxy)

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CheckmarxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CheckmarxScanBuilder.java
@@ -13,6 +13,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.*;
 import hudson.model.*;
 import hudson.security.ACL;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
@@ -52,8 +53,12 @@ public class CheckmarxScanBuilder extends Builder implements SimpleBuildStep {
     public static final String DEFAULT_BRANCH_WARN = "If blank, branch name points to %s, %s or %s environment variables";
 
     public static final String GIT_BRANCH = "GIT_BRANCH";
+    public static final String GIT_BRANCH_VAR = "${GIT_BRANCH}";
     public static final String CVS_BRANCH = "CVS_BRANCH";
+    public static final String CVS_BRANCH_VAR = "${CVS_BRANCH}";
     public static final String SVN_REVISION = "SVN_REVISION";
+    public static final String SVN_REVISION_VAR = "${SVN_REVISION}";
+
 
     CxLoggerAdapter log;
     @Nullable
@@ -213,7 +218,7 @@ public class CheckmarxScanBuilder extends Builder implements SimpleBuildStep {
             return;
         }
 
-        printConfiguration(scanConfig, log);
+        printConfiguration(envVars, descriptor, log);
 
         if (!getUseOwnServerCredentials()) checkmarxInstallation = descriptor.getCheckmarxInstallation();
         //// Check for required version of CLI
@@ -255,8 +260,6 @@ public class CheckmarxScanBuilder extends Builder implements SimpleBuildStep {
             return;
         }
 
-
-
         try {
             final Scan scan = PluginUtils.submitScanDetailsToWrapper(scanConfig, checkmarxCliExecutable, this.log);
             PluginUtils.generateHTMLReport(workspace, UUID.fromString(scan.getID()), scanConfig, checkmarxCliExecutable, log);
@@ -286,71 +289,94 @@ public class CheckmarxScanBuilder extends Builder implements SimpleBuildStep {
      */
     private String getBranchNameOrDefault(EnvVars envVars) {
 
-        if (!StringUtils.isEmpty(getBranchName())) return getBranchName();
-        if (!StringUtils.isEmpty(envVars.get(GIT_BRANCH))) return envVars.get(GIT_BRANCH).replaceAll("^([^/]+)/", "");
-        if (!StringUtils.isEmpty(envVars.get(CVS_BRANCH))) return envVars.get(CVS_BRANCH);
-        if (!StringUtils.isEmpty(envVars.get(SVN_REVISION))) return envVars.get(SVN_REVISION);
+        if (StringUtils.isNotEmpty(getBranchName())) return envVars.expand(getBranchName());
+        if (StringUtils.isNotEmpty(envVars.get(GIT_BRANCH))) return envVars.get(GIT_BRANCH).replaceAll("^([^/]+)/", "");
+        if (StringUtils.isNotEmpty(envVars.get(CVS_BRANCH))) return envVars.get(CVS_BRANCH);
+        if (StringUtils.isNotEmpty(envVars.get(SVN_REVISION))) return envVars.get(SVN_REVISION);
 
         return "";
     }
 
-    private void printConfiguration(ScanConfig scanConfig, CxLoggerAdapter log) {
-        log.info("----**** Checkmarx Scan Configuration ****----");
-        log.info("Checkmarx Server Url: " + scanConfig.getServerUrl());
-        if (StringUtils.isNotEmpty(scanConfig.getBaseAuthUrl())) {
-            log.info("Checkmarx Auth Server Url: " + scanConfig.getBaseAuthUrl());
-        }
-        log.info("Tenant Name: " + Optional.ofNullable(scanConfig.getTenantName()).orElse(""));
-        log.info("Project Name: " + Optional.ofNullable(scanConfig.getProjectName()).orElse(""));
+    /**
+     * Return branch name to print
+     *
+     * @param envVars
+     * @return
+     */
+    private String getBranchToPrint(EnvVars envVars){
 
-        log.info("Branch name: " + scanConfig.getBranchName());
+        if(StringUtils.isNotEmpty(getBranchName())) return getBranchName();
+        if(StringUtils.isNotEmpty(envVars.get(GIT_BRANCH))) return GIT_BRANCH_VAR;
+        if(StringUtils.isNotEmpty(envVars.get(CVS_BRANCH))) return CVS_BRANCH_VAR;
+        if(StringUtils.isNotEmpty(envVars.get(SVN_REVISION))) return SVN_REVISION_VAR;
+
+        return "";
+    }
+
+    /**
+     * Prints scan configuration which is gonna be used by the CLI
+     *
+     * @param envVars
+     * @param descriptor
+     * @param log
+     */
+    private void printConfiguration(EnvVars envVars, CheckmarxScanBuilderDescriptor descriptor, CxLoggerAdapter log) {
+        log.info("----**** Checkmarx Scan Configuration ****----");
+
+        String serverUrl = getUseOwnServerCredentials() ? getServerUrl() : descriptor.getServerUrl();
+        log.info("Checkmarx Server Url: " + serverUrl);
+
+        boolean useOwnBaseAuthUrl = getUseOwnServerCredentials() && isUseAuthenticationUrl();
+        boolean useGlobalAuthUrl = !useOwnBaseAuthUrl && descriptor.getUseAuthenticationUrl();
+        String authUrl = useOwnBaseAuthUrl ? getBaseAuthUrl() : useGlobalAuthUrl ? descriptor.getBaseAuthUrl() : "";
+
+        if (StringUtils.isNotEmpty(authUrl)) {
+            log.info("Checkmarx Auth Server Url: " + authUrl);
+        }
+
+        String tenantName = getUseOwnServerCredentials() ? getTenantName() : descriptor.getTenantName();
+        log.info("Tenant Name: " + Optional.ofNullable(tenantName).orElse(""));
+        log.info("Project Name: " + getProjectName());
+        log.info("Branch name: " + getBranchToPrint(envVars));
 
         log.info("Using global additional options: " + !getUseOwnAdditionalOptions());
-        log.info("Additional Options: " + Optional.ofNullable(scanConfig.getAdditionalOptions()).orElse(""));
+
+        String additionalOptions = getUseOwnAdditionalOptions() ? getAdditionalOptions() : descriptor.getAdditionalOptions();
+        log.info("Additional Options: " + Optional.ofNullable(additionalOptions).orElse(""));
 
     }
 
     private ScanConfig resolveConfiguration(Run<?, ?> run, FilePath workspace, CheckmarxScanBuilderDescriptor descriptor, EnvVars envVars) throws Exception {
+
+        checkMandatoryFields(descriptor);
+
         ScanConfig scanConfig = new ScanConfig();
-
-        if (fixEmptyAndTrim(getProjectName()) == null)
-            throw new Exception("Please provide a valid project name.");
-        if (!getUseOwnServerCredentials() && fixEmptyAndTrim(descriptor.getServerUrl()) == null)
-            throw new Exception("Please setup the server url in the global settings.");
-        if (!getUseOwnServerCredentials() && fixEmptyAndTrim(descriptor.getCredentialsId()) == null)
-            throw new Exception("Please setup the credential in the global settings");
-
-        scanConfig.setProjectName(getProjectName());
+        scanConfig.setProjectName(envVars.expand(getProjectName()));
 
         if (descriptor.getUseAuthenticationUrl()) {
-            scanConfig.setBaseAuthUrl(descriptor.getBaseAuthUrl());
+            scanConfig.setBaseAuthUrl(envVars.expand(descriptor.getBaseAuthUrl()));
         }
 
         if (this.getUseOwnServerCredentials()) {
-            scanConfig.setServerUrl(getServerUrl());
-            scanConfig.setTenantName(fixEmptyAndTrim(getTenantName()));
+            scanConfig.setServerUrl(envVars.expand(getServerUrl()));
+            scanConfig.setTenantName(envVars.expand(fixEmptyAndTrim(getTenantName())));
             if (this.isUseAuthenticationUrl()) {
-                scanConfig.setBaseAuthUrl(this.getBaseAuthUrl());
+                scanConfig.setBaseAuthUrl(envVars.expand(this.getBaseAuthUrl()));
             }
             scanConfig.setCheckmarxToken(getCheckmarxTokenCredential(run, getCredentialsId()));
 
         } else {
-            scanConfig.setServerUrl(descriptor.getServerUrl());
-            scanConfig.setTenantName(fixEmptyAndTrim(descriptor.getTenantName()));
+            scanConfig.setServerUrl(envVars.expand(descriptor.getServerUrl()));
+            scanConfig.setTenantName(envVars.expand(fixEmptyAndTrim(descriptor.getTenantName())));
             scanConfig.setCheckmarxToken(getCheckmarxTokenCredential(run, descriptor.getCredentialsId()));
         }
 
         String branchName = getBranchNameOrDefault(envVars);
         scanConfig.setBranchName(branchName);
 
-        String additionalOptions;
-        if (getUseOwnAdditionalOptions()) {
-            additionalOptions = getAdditionalOptions();
-        } else {
-            additionalOptions = descriptor.getAdditionalOptions();
-        }
+        String additionalOptions = getUseOwnAdditionalOptions() ? getAdditionalOptions() : descriptor.getAdditionalOptions();
         if (fixEmptyAndTrim(additionalOptions) != null) {
-            scanConfig.setAdditionalOptions(additionalOptions);
+            scanConfig.setAdditionalOptions(envVars.expand(additionalOptions));
         }
 
         File file = new File(workspace.getRemote());
@@ -358,6 +384,20 @@ public class CheckmarxScanBuilder extends Builder implements SimpleBuildStep {
         scanConfig.setSourceDirectory(sourceDir);
 
         return scanConfig;
+    }
+
+    /**
+     * Check if all mandatory fields are filled in
+     *
+     * @throws Exception
+     */
+    private void checkMandatoryFields(CheckmarxScanBuilderDescriptor descriptor) throws Exception {
+        if (fixEmptyAndTrim(getProjectName()) == null)
+            throw new Exception("Please provide a valid project name.");
+        if (!getUseOwnServerCredentials() && fixEmptyAndTrim(descriptor.getServerUrl()) == null)
+            throw new Exception("Please setup the server url in the global settings.");
+        if (!getUseOwnServerCredentials() && fixEmptyAndTrim(descriptor.getCredentialsId()) == null)
+            throw new Exception("Please setup the credential in the global settings");
     }
 
     private CheckmarxApiToken getCheckmarxTokenCredential(Run<?, ?> run, String credentialsId) {
@@ -513,10 +553,12 @@ public class CheckmarxScanBuilder extends Builder implements SimpleBuildStep {
                 String cxInstallationPath = getCheckmarxInstallationPath(checkmarxInstallation);
                 CheckmarxApiToken checkmarxApiToken = getCheckmarxApiToken(credentialsId);
 
+                EnvVars envVars = ((EnvironmentVariablesNodeProperty) Jenkins.get().getGlobalNodeProperties().get(0)).getEnvVars();
+
                 ScanConfig scanConfig = new ScanConfig();
-                scanConfig.setServerUrl(serverUrl);
-                scanConfig.setBaseAuthUrl(useAuthenticationUrl ? baseAuthUrl : null);
-                scanConfig.setTenantName(tenantName);
+                scanConfig.setServerUrl(envVars.expand(serverUrl));
+                scanConfig.setBaseAuthUrl(useAuthenticationUrl ? envVars.expand(baseAuthUrl) : null);
+                scanConfig.setTenantName(envVars.expand(tenantName));
                 scanConfig.setCheckmarxToken(checkmarxApiToken);
 
                 String message = PluginUtils.authValidate(scanConfig, cxInstallationPath);
@@ -560,7 +602,7 @@ public class CheckmarxScanBuilder extends Builder implements SimpleBuildStep {
         }
 
         public FormValidation doCheckBranchName(@QueryParameter String value) {
-            return FormValidation.warning(String.format(DEFAULT_BRANCH_WARN, GIT_BRANCH, CVS_BRANCH, SVN_REVISION));
+            return FormValidation.warning(String.format(DEFAULT_BRANCH_WARN, GIT_BRANCH_VAR, CVS_BRANCH_VAR, SVN_REVISION_VAR));
         }
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String credentialsId) {

--- a/src/test/java/com/checkmarx/jenkins/CheckmarxScanBuilderTest.java
+++ b/src/test/java/com/checkmarx/jenkins/CheckmarxScanBuilderTest.java
@@ -11,30 +11,23 @@ import java.util.logging.Logger;
 
 public class CheckmarxScanBuilderTest extends CheckmarxTestBase {
 
+    private static final String CX_BASE_URI_ENV_VAR = String.format("${%s}",TEST_CX_BASE_URI);
+    private static final String CX_TENANT_ENV_VAR = String.format("${%s}",TEST_CX_TENANT);
+    private static final String CX_PROJECT_NAME_ENV_VAR = String.format("${%s}",TEST_CX_PROJECT_NAME);
+    private static final String CX_BRANCH_NAME_ENV_VAR = String.format("${%s}",TEST_CX_BRANCH_NAME);
+
     private static final Logger log = Logger.getLogger(CheckmarxScanBuilderTest.class.getName());
 
     @Test
     public void successCheckmarxScan() throws Exception {
         log.info("successCheckmarxScan");
+        runSuccessCheckmarxScan(this.astServerUrl, "successIntegrationJenkinsScan", this.astTenantName, "master");
+    }
 
-        final FreeStyleProject freeStyleProject = createSimpleProject("successIntegrationJenkinsScan");
-
-        final CheckmarxScanBuilder checkmarxScanBuilder = new CheckmarxScanBuilder();
-        checkmarxScanBuilder.setUseOwnServerCredentials(true);
-        checkmarxScanBuilder.setProjectName("successIntegrationJenkinsScan");
-        checkmarxScanBuilder.setServerUrl(this.astServerUrl);
-        checkmarxScanBuilder.setUseAuthenticationUrl(StringUtils.isNotEmpty(this.astBaseAuthUrl));
-        checkmarxScanBuilder.setBaseAuthUrl(this.astBaseAuthUrl);
-        checkmarxScanBuilder.setTenantName(this.astTenantName);
-        checkmarxScanBuilder.setCheckmarxInstallation(Constants.JT_LATEST);
-        checkmarxScanBuilder.setCredentialsId(Constants.JT_TOKEN_ID);
-        checkmarxScanBuilder.setAdditionalOptions("--scan-types sast");
-        checkmarxScanBuilder.setUseOwnAdditionalOptions(true);
-
-        freeStyleProject.getBuildersList().add(checkmarxScanBuilder);
-
-        final FreeStyleBuild build = freeStyleProject.scheduleBuild2(0).get();
-        this.jenkins.assertBuildStatus(Result.SUCCESS, build);
+    @Test
+    public void successCheckmarxScanWithEnvironmentVariables() throws Exception {
+        log.info("successCheckmarxScanWithEnvironmentVariables");
+        runSuccessCheckmarxScan(CX_BASE_URI_ENV_VAR, CX_PROJECT_NAME_ENV_VAR, CX_TENANT_ENV_VAR, CX_BRANCH_NAME_ENV_VAR);
     }
 
     @Test
@@ -128,5 +121,36 @@ public class CheckmarxScanBuilderTest extends CheckmarxTestBase {
         final FreeStyleBuild build = freeStyleProject.scheduleBuild2(0).get();
         this.jenkins.assertBuildStatus(Result.FAILURE, build);
         this.jenkins.assertLogContains("Please provide a valid project name.", build);
+    }
+
+    /**
+     * Runs a checkmarx scan successfully
+     *
+     * @param serverUrl - ast server url
+     * @param projectName - ast project name
+     * @param tenant - ast tenant
+     * @param branch - ast branch
+     * @throws Exception
+     */
+    private void runSuccessCheckmarxScan(String serverUrl, String projectName, String tenant, String branch) throws Exception {
+        final FreeStyleProject freeStyleProject = createSimpleProject("successIntegrationJenkinsScan");
+
+        final CheckmarxScanBuilder checkmarxScanBuilder = new CheckmarxScanBuilder();
+        checkmarxScanBuilder.setUseOwnServerCredentials(true);
+        checkmarxScanBuilder.setProjectName(projectName);
+        checkmarxScanBuilder.setServerUrl(serverUrl);
+        checkmarxScanBuilder.setTenantName(tenant);
+        checkmarxScanBuilder.setBranchName(branch);
+        checkmarxScanBuilder.setUseAuthenticationUrl(StringUtils.isNotEmpty(this.astBaseAuthUrl));
+        checkmarxScanBuilder.setBaseAuthUrl(this.astBaseAuthUrl);
+        checkmarxScanBuilder.setCheckmarxInstallation(Constants.JT_LATEST);
+        checkmarxScanBuilder.setCredentialsId(Constants.JT_TOKEN_ID);
+        checkmarxScanBuilder.setAdditionalOptions("--scan-types sast");
+        checkmarxScanBuilder.setUseOwnAdditionalOptions(true);
+
+        freeStyleProject.getBuildersList().add(checkmarxScanBuilder);
+
+        final FreeStyleBuild build = freeStyleProject.scheduleBuild2(0).get();
+        this.jenkins.assertBuildStatus(Result.SUCCESS, build);
     }
 }

--- a/src/test/java/com/checkmarx/jenkins/CheckmarxTestBase.java
+++ b/src/test/java/com/checkmarx/jenkins/CheckmarxTestBase.java
@@ -7,8 +7,11 @@ import com.checkmarx.jenkins.utils.Constants;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.domains.Domain;
+import hudson.EnvVars;
 import hudson.model.FreeStyleProject;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.tools.InstallSourceProperty;
+import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -19,6 +22,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CheckmarxTestBase {
+
+    public static final String TEST_CX_BASE_URI = "TEST_CX_BASE_URI";
+    public static final String TEST_CX_TENANT = "TEST_CX_TENANT";
+    public static final String TEST_CX_PROJECT_NAME = "TEST_CX_PROJECT_NAME";
+    public static final String TEST_CX_BRANCH_NAME = "TEST_CX_BRANCH_NAME";
 
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
@@ -39,6 +47,8 @@ public class CheckmarxTestBase {
 
         createInstallation();
         createCredentials();
+
+        setJenkinsEnvironmentVariables();
     }
 
     protected FreeStyleProject createSimpleProject(String projectName) throws IOException {
@@ -72,5 +82,20 @@ public class CheckmarxTestBase {
         jenkins.getInstance()
                 .getDescriptorByType(CheckmarxScanBuilder.CheckmarxScanBuilderDescriptor.class)
                 .setInstallations(expected);
+    }
+
+    /**
+     * Defines some jenkins environment variables
+     */
+    private void setJenkinsEnvironmentVariables(){
+
+        EnvironmentVariablesNodeProperty.Entry cx_base_uri = new EnvironmentVariablesNodeProperty.Entry(TEST_CX_BASE_URI, this.astServerUrl);
+        EnvironmentVariablesNodeProperty cx_base_uri_var = new EnvironmentVariablesNodeProperty(cx_base_uri);
+        jenkins.getInstance().getGlobalNodeProperties().add(cx_base_uri_var);
+
+        EnvVars envVars = ((EnvironmentVariablesNodeProperty) Jenkins.get().getGlobalNodeProperties().get(0)).getEnvVars();
+        envVars.put(TEST_CX_TENANT, this.astTenantName);
+        envVars.put(TEST_CX_PROJECT_NAME, "jenkins_project_with_env_vars");
+        envVars.put(TEST_CX_BRANCH_NAME, "master");
     }
 }


### PR DESCRIPTION
- Allow user to use Jenkins environment variables by using envVars.expand method to translate variables with the following syntax ${ENV_VAR} or $ENV_VAR;